### PR TITLE
Fix center alignment of text

### DIFF
--- a/dist/kubernetes_C4.puml
+++ b/dist/kubernetes_C4.puml
@@ -11,7 +11,7 @@
 
 !define TECHN_FONT_SIZE 12
 
-skinparam defaultTextAlignment left
+skinparam defaultTextAlignment center
 
 skinparam wrapWidth 200
 skinparam maxMessageSize 150


### PR DESCRIPTION
Center alignment of text is declared to center in https://github.com/dcasati/kubernetes-PlantUML/blob/dee6e17448ddc348a8e5a739419e5b1946f8db53/dist/kubernetes_Common.puml#L13 and overwritten by this. Left aligned node names look quite strange, so changing this as well to center aligned.